### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ If you want to use the widget in the admin panel, you can subclass the ``MirrorA
             ('comment', {
                 'mode': 'markdown',
                 'line_wrapping': True,
-            })
+            }),
         )
 
 The mixin also includes a bit of css to make CodeMirror look more like regular admin textarea fields.


### PR DESCRIPTION
Hi! I add semicolon in mirror_fields tuple, because without it this condition https://github.com/pavelsof/django-mirror/blob/master/django_mirror/admin.py#L36 doesn't work properly and setup widget without any options.